### PR TITLE
Added Download section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains a set of [Kibana dashboards](https://www.elastic.co/gui
 
 **Please note:** These dashboards only work with Kibana and Enterprise Search versions 7.16.0 and higher. Dashboards differ between versions of the stack, so please pick the version closest to your current release, but not higher (8.0 for any 8.x release, 7.16 for releases before 8.0).
 
+## Download
+
+To download the dashboards, use the **Code** > **Download ZIP** option on this page. Extract the resulting .zip file and obtain the `dashboard/{VERSION}/*.ndjson` file(s) for your specific Enterprise Search version.
+
 ## Installation
 
 Dashboards are imported on the **Stack Management > Saved objects** page. Full documentation on this process is available in [Kibana](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html).


### PR DESCRIPTION
Directing users to use the `Code > Download ZIP` option to download the files as the recommended way to download the files. If users not familiar with GitHub UI goes straight to the file directory and use browser's `Save Link As` (instead of the `View Raw` link), it will end up with an invalid .ndjson file.