### PR TITLE
Added Filebeat configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,13 @@
 <p align="center"><img src="https://github.com/elastic/ent-search-monitoring/blob/main/logo-enterprise-search.png?raw=true" alt="Elastic Enterprise Search Logo"></p>
 
-# Elastic Enterprise Search Monitoring Dashboard
+# Elastic Enterprise Search Monitoring
 
-This repository contains a set of [Kibana dashboards](https://www.elastic.co/guide/en/kibana/current/dashboard.html) to be used with [Elastic Enterprise Search](https://www.elastic.co/enterprise-search) and Elastic Metricbeat for monitoring production deployments.
-
-**Please note:** These dashboards only work with Kibana and Enterprise Search versions 7.16.0 and higher. Dashboards differ between versions of the stack, so please pick the version closest to your current release, but not higher (8.0 for any 8.x release, 7.16 for releases before 8.0).
+This repository contains:
+- [Kibana dashboards](dashboard) to be used with [Elastic Enterprise Search](https://www.elastic.co/enterprise-search) and Elastic Metricbeat for monitoring production deployments.
+- [Filebeat configuration](filebeat) to be used with [Filebeat](https://www.elastic.co/guide/en/beats/filebeat) in order to ingest Enterprise Search log files into Elasticsearch.
 
 ## Download
 
-To download the dashboards, use the **Code** > **Download ZIP** option on this page. Extract the resulting .zip file and obtain the `dashboard/{VERSION}/*.ndjson` file(s) for your specific Enterprise Search version.
+To download this repository, use the **Code** > **Download ZIP** option on this page.
 
-## Installation
-
-Dashboards are imported on the **Stack Management > Saved objects** page. Full documentation on this process is available in [Kibana](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html).
-
-After importing, visit the [Dashboard](https://www.elastic.co/guide/en/kibana/current/dashboard.html) tab to view and edit your imported dashboards.
-
-For more information on Enterprise Search monitoring, please refer to [Enterprise Search documentation](https://www.elastic.co/guide/en/enterprise-search/current/index.html).
-
-## Dashboards
-
-The following dashboards are available at this time:
-
-### Enterprise Search Overview
-
-Use this dashboard for self-managed Enterprise Search deployments.
-
-A general monitoring overview page with product usage information, HTTP metrics, low-level resource utilization information (JVM metrics) and background workers details.
-
-This dashboard should work with standalone Metricbeat deployments and with Enterprise Search deployments running metricbeat as an internal monitoring component (see `monitoring.*` settings in `enterprise_search.yml`) starting with version 7.16.
-
-
-### Enterprise Search Overview - Cloud
-
-It provides the Enterprise Search Overview dashboard for Elasticsearch Service managed deployments of Enterprise Search.
+Extract the resulting .zip file and refer to the setup instructions on each subdirectory.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -20,11 +20,11 @@ The following dashboards are available at this time:
 
 Use this dashboard for self-managed Enterprise Search deployments.
 
-A general monitoring overview page with product usage information, HTTP metrics, low-level resource utilization information (JVM metrics) and background workers details.
+This dashboard provides a general monitoring overview page with product usage information, HTTP metrics, low-level resource utilization information (JVM metrics) and background workers details.
 
-This dashboard should work with standalone Metricbeat deployments and with Enterprise Search deployments running metricbeat as an internal monitoring component (see `monitoring.*` settings in `enterprise_search.yml`) starting with version 7.16.
+This dashboard works with standalone Metricbeat deployments and with Enterprise Search deployments running Metricbeat as an internal monitoring component. See `monitoring.*` settings in `enterprise_search.yml` starting with version 7.16.
 
 
 ### Enterprise Search Overview - Cloud
 
-It provides the Enterprise Search Overview dashboard for Elasticsearch Service managed deployments of Enterprise Search.
+Use this dashboard for Enterprise Search deployments running on Elastic Cloud.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,30 @@
+# Elastic Enterprise Search Monitoring Dashboard
+
+This directory contains a set of [Kibana dashboards](https://www.elastic.co/guide/en/kibana/current/dashboard.html) to be used with [Elastic Enterprise Search](https://www.elastic.co/enterprise-search) and Elastic Metricbeat for monitoring production deployments.
+
+**Please note:** These dashboards only work with Kibana and Enterprise Search versions 7.16.0 and higher. Dashboards differ between versions of the stack, so please pick the version closest to your current release, but not higher (8.0 for any 8.x release, 7.16 for releases before 8.0).
+
+## Installation
+
+Dashboards are imported on the **Stack Management > Saved objects** page. Full documentation on this process is available in [Kibana](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html).
+
+After importing, visit the [Dashboard](https://www.elastic.co/guide/en/kibana/current/dashboard.html) tab to view and edit your imported dashboards.
+
+For more information on Enterprise Search monitoring, please refer to [Enterprise Search documentation](https://www.elastic.co/guide/en/enterprise-search/current/index.html).
+
+## Dashboards
+
+The following dashboards are available at this time:
+
+### Enterprise Search Overview
+
+Use this dashboard for self-managed Enterprise Search deployments.
+
+A general monitoring overview page with product usage information, HTTP metrics, low-level resource utilization information (JVM metrics) and background workers details.
+
+This dashboard should work with standalone Metricbeat deployments and with Enterprise Search deployments running metricbeat as an internal monitoring component (see `monitoring.*` settings in `enterprise_search.yml`) starting with version 7.16.
+
+
+### Enterprise Search Overview - Cloud
+
+It provides the Enterprise Search Overview dashboard for Elasticsearch Service managed deployments of Enterprise Search.

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -2,17 +2,19 @@
 
 This directory contains Filebeat configuration to be used with [Filebeat](https://www.elastic.co/guide/en/beats/filebeat) in order to ingest Enterprise Search log files into Elasticsearch.
 
+This example configuration assumes Filebeat and Elasticsearch versions 8.x  
+
 ## Installation
 
 1. [Download Filebeat](https://www.elastic.co/downloads/beats/filebeat)
 2. Replace `filebeat.yml` file in the Filebeat install directory with the one in this directory
-3. Customize `filebeat.yml` with the needed information:
-   - Elasticsearch host, username and password
-   - SSL verification mode
-   - Enterprise Search install directory
-   - Filebeat log directory
-   - Additional fields to be included in the log events
+3. Customize `filebeat.yml` with the needed information
+   - Elasticsearch hosts, username and password, or additional authentication mechanisms. Check [Configure the Elasticsearch output](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#elasticsearch-output) in Filebeat reference for additional details.
+   - Enterprise Search install directory.
+   - Filebeat log directory.
+   - Additional fields to be included in the log events.
+
 4. Run [Filebeat setup assets](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#setup-assets)
 5. [Start Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#start)
 
-Enterprise Search logs will be ingested into `filebeat-<filebeat_version>` index in the configured Elasticsearch instance.
+Enterprise Search logs will be ingested into `ent-search-logs-8` data stream in the configured Elasticsearch instance, and will be visible in the Observability / Logs section in Kibana.

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -2,19 +2,19 @@
 
 This directory contains Filebeat configuration to be used with [Filebeat](https://www.elastic.co/guide/en/beats/filebeat) in order to ingest Enterprise Search log files into Elasticsearch.
 
-This example configuration assumes Filebeat and Elasticsearch versions 8.x  
+This example configuration assumes Filebeat and Elasticsearch versions 8.x.
 
 ## Installation
 
 1. [Download Filebeat](https://www.elastic.co/downloads/beats/filebeat)
 2. Replace `filebeat.yml` file in the Filebeat install directory with the one in this directory
-3. Customize `filebeat.yml` with the needed information
+4. Customize `filebeat.yml` with the needed information
    - Elasticsearch hosts, username and password, or additional authentication mechanisms. Check [Configure the Elasticsearch output](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#elasticsearch-output) in Filebeat reference for additional details.
    - Enterprise Search install directory.
    - Filebeat log directory.
    - Additional fields to be included in the log events.
 
-4. Run [Filebeat setup assets](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#setup-assets)
-5. [Start Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#start)
+5. Run [Filebeat setup assets](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#setup-assets)
+6. [Start Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#start)
 
 Enterprise Search logs will be ingested into `ent-search-logs-8` data stream in the configured Elasticsearch instance, and will be visible in the Observability / Logs section in Kibana.

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -6,15 +6,16 @@ This example configuration assumes Filebeat and Elasticsearch versions 8.x.
 
 ## Installation
 
-1. [Download Filebeat](https://www.elastic.co/downloads/beats/filebeat)
-2. Replace `filebeat.yml` file in the Filebeat install directory with the one in this directory
+1. [Download Filebeat](https://www.elastic.co/downloads/beats/filebeat).
+2. Replace `filebeat.yml` file in the Filebeat install directory with the one in this directory.
+3. Copy filebeat-template-8.json from this directory into your Filebeat install directory.
 4. Customize `filebeat.yml` with the needed information
    - Elasticsearch hosts, username and password, or additional authentication mechanisms. Check [Configure the Elasticsearch output](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#elasticsearch-output) in Filebeat reference for additional details.
    - Enterprise Search install directory.
    - Filebeat log directory.
    - Additional fields to be included in the log events.
 
-5. Run [Filebeat setup assets](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#setup-assets)
-6. [Start Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#start)
+5. Run [Filebeat setup assets](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#setup-assets).
+6. [Start Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#start).
 
 Enterprise Search logs will be ingested into `ent-search-logs-8` data stream in the configured Elasticsearch instance, and will be visible in the Observability / Logs section in Kibana.

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -1,0 +1,18 @@
+# Elastic Enterprise Search Filebeat configuration
+
+This directory contains Filebeat configuration to be used with [Filebeat](https://www.elastic.co/guide/en/beats/filebeat) in order to ingest Enterprise Search log files into Elasticsearch.
+
+## Installation
+
+1. [Download Filebeat](https://www.elastic.co/downloads/beats/filebeat)
+2. Replace `filebeat.yml` file in the Filebeat install directory with the one in this directory
+3. Customize `filebeat.yml` with the needed information:
+   - Elasticsearch host, username and password
+   - SSL verification mode
+   - Enterprise Search install directory
+   - Filebeat log directory
+   - Additional fields to be included in the log events
+4. Run [Filebeat setup assets](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#setup-assets)
+5. [Start Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#start)
+
+Enterprise Search logs will be ingested into `filebeat-<filebeat_version>` index in the configured Elasticsearch instance.

--- a/filebeat/filebeat-template-8.json
+++ b/filebeat/filebeat-template-8.json
@@ -1,0 +1,3962 @@
+{
+  "index_patterns": [
+    "ent-search-logs-8*"
+  ],
+  "priority": 1000,
+  "version": 1,
+  "data_stream": {},
+  "template": {
+    "aliases": {
+      "filebeat-ent-search-logs-8": {}
+    },
+    "mappings": {
+      "_meta": {
+        "beat": "filebeat",
+        "version": "8"
+      },
+      "date_detection": false,
+      "dynamic_templates": [
+        {
+          "labels": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "labels.*"
+          }
+        },
+        {
+          "container.labels": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "container.labels.*"
+          }
+        },
+        {
+          "dns.answers": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "dns.answers.*"
+          }
+        },
+        {
+          "log.syslog": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "log.syslog.*"
+          }
+        },
+        {
+          "network.inner": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "network.inner.*"
+          }
+        },
+        {
+          "observer.egress": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "observer.egress.*"
+          }
+        },
+        {
+          "observer.ingress": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "observer.ingress.*"
+          }
+        },
+        {
+          "fields": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        },
+        {
+          "docker.container.labels": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "docker.container.labels.*"
+          }
+        },
+        {
+          "docker.attrs": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "docker.attrs.*"
+          }
+        },
+        {
+          "kibana.log.meta": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "kibana.log.meta.*"
+          }
+        },
+        {
+          "strings_as_keyword": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "agent": {
+          "properties": {
+            "ephemeral_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "as": {
+          "properties": {
+            "number": {
+              "type": "long"
+            },
+            "organization": {
+              "properties": {
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "azure": {
+          "properties": {
+            "consumer_group": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "enqueued_time": {
+              "type": "date"
+            },
+            "eventhub": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "offset": {
+              "type": "long"
+            },
+            "partition_id": {
+              "type": "long"
+            },
+            "sequence_number": {
+              "type": "long"
+            }
+          }
+        },
+        "client": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "cloud": {
+          "properties": {
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "code_signature": {
+          "properties": {
+            "exists": {
+              "type": "boolean"
+            },
+            "status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subject_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "trusted": {
+              "type": "boolean"
+            },
+            "valid": {
+              "type": "boolean"
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tag": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "labels": {
+              "type": "object"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "runtime": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "destination": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "dll": {
+          "properties": {
+            "code_signature": {
+              "properties": {
+                "exists": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "hash": {
+              "properties": {
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "pe": {
+              "properties": {
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "dns": {
+          "properties": {
+            "answers": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "header_flags": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "op_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "question": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "registered_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subdomain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "top_level_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "resolved_ip": {
+              "type": "ip"
+            },
+            "response_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "docker": {
+          "properties": {
+            "attrs": {
+              "type": "object"
+            },
+            "container": {
+              "properties": {
+                "labels": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "elasticsearch": {
+          "properties": {
+            "audit": {
+              "properties": {
+                "action": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "event_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "indices": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "layer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "message": {
+                  "norms": false,
+                  "type": "text"
+                },
+                "origin": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "realm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "request": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "url": {
+                  "properties": {
+                    "params": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "user": {
+                  "properties": {
+                    "realm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "cluster": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "uuid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "component": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "deprecation": {
+              "properties": {}
+            },
+            "gc": {
+              "properties": {
+                "heap": {
+                  "properties": {
+                    "size_kb": {
+                      "type": "long"
+                    },
+                    "used_kb": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "jvm_runtime_sec": {
+                  "type": "float"
+                },
+                "old_gen": {
+                  "properties": {
+                    "size_kb": {
+                      "type": "long"
+                    },
+                    "used_kb": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "phase": {
+                  "properties": {
+                    "class_unload_time_sec": {
+                      "type": "float"
+                    },
+                    "cpu_time": {
+                      "properties": {
+                        "real_sec": {
+                          "type": "float"
+                        },
+                        "sys_sec": {
+                          "type": "float"
+                        },
+                        "user_sec": {
+                          "type": "float"
+                        }
+                      }
+                    },
+                    "duration_sec": {
+                      "type": "float"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "parallel_rescan_time_sec": {
+                      "type": "float"
+                    },
+                    "scrub_string_table_time_sec": {
+                      "type": "float"
+                    },
+                    "scrub_symbol_table_time_sec": {
+                      "type": "float"
+                    },
+                    "weak_refs_processing_time_sec": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "stopping_threads_time_sec": {
+                  "type": "float"
+                },
+                "tags": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "threads_total_stop_time_sec": {
+                  "type": "float"
+                },
+                "young_gen": {
+                  "properties": {
+                    "size_kb": {
+                      "type": "long"
+                    },
+                    "used_kb": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "index": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "node": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "server": {
+              "properties": {
+                "gc": {
+                  "properties": {
+                    "collection_duration": {
+                      "properties": {
+                        "ms": {
+                          "type": "float"
+                        }
+                      }
+                    },
+                    "observation_duration": {
+                      "properties": {
+                        "ms": {
+                          "type": "float"
+                        }
+                      }
+                    },
+                    "overhead_seq": {
+                      "type": "long"
+                    },
+                    "young": {
+                      "properties": {
+                        "one": {
+                          "type": "long"
+                        },
+                        "two": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "stacktrace": {
+                  "ignore_above": 1024,
+                  "index": false,
+                  "type": "keyword"
+                }
+              }
+            },
+            "shard": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "slowlog": {
+              "properties": {
+                "extra_source": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "logger": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "routing": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "search_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "source": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "source_query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "stats": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "took": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "total_hits": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "total_shards": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "types": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "error": {
+          "properties": {
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message": {
+              "norms": false,
+              "type": "text"
+            },
+            "stack_trace": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "action": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "created": {
+              "type": "date"
+            },
+            "dataset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "duration": {
+              "type": "long"
+            },
+            "end": {
+              "type": "date"
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingested": {
+              "type": "date"
+            },
+            "kind": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "module": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outcome": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "risk_score": {
+              "type": "float"
+            },
+            "risk_score_norm": {
+              "type": "float"
+            },
+            "sequence": {
+              "type": "long"
+            },
+            "severity": {
+              "type": "long"
+            },
+            "start": {
+              "type": "date"
+            },
+            "timezone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "url": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "fields": {
+          "type": "object"
+        },
+        "file": {
+          "properties": {
+            "accessed": {
+              "type": "date"
+            },
+            "attributes": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "code_signature": {
+              "properties": {
+                "exists": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "created": {
+              "type": "date"
+            },
+            "ctime": {
+              "type": "date"
+            },
+            "device": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "directory": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "drive_letter": {
+              "ignore_above": 1,
+              "type": "keyword"
+            },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "gid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hash": {
+              "properties": {
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "inode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mime_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mtime": {
+              "type": "date"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "owner": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "pe": {
+              "properties": {
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "size": {
+              "type": "long"
+            },
+            "target_path": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "fileset": {
+          "properties": {
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "geo": {
+          "properties": {
+            "city_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "continent_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "country_iso_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "country_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "location": {
+              "type": "geo_point"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region_iso_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "group": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "hash": {
+          "properties": {
+            "md5": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "sha1": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "sha256": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "sha512": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uptime": {
+              "type": "long"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "http": {
+          "properties": {
+            "request": {
+              "properties": {
+                "body": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "content": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "method": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "referrer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "body": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "content": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "status_code": {
+                  "type": "long"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "icmp": {
+          "properties": {
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "igmp": {
+          "properties": {
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "input": {
+          "properties": {
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "interface": {
+          "properties": {
+            "alias": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "kafka": {
+          "properties": {
+            "block_timestamp": {
+              "type": "date"
+            },
+            "key": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "offset": {
+              "type": "long"
+            },
+            "partition": {
+              "type": "long"
+            },
+            "topic": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "kibana": {
+          "properties": {
+            "log": {
+              "properties": {
+                "meta": {
+                  "type": "object"
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tags": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "labels": {
+          "type": "object"
+        },
+        "log": {
+          "properties": {
+            "file": {
+              "properties": {
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "flags": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "logger": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "offset": {
+              "type": "long"
+            },
+            "origin": {
+              "properties": {
+                "file": {
+                  "properties": {
+                    "line": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "function": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "original": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "source": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "syslog": {
+              "properties": {
+                "facility": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "priority": {
+                  "type": "long"
+                },
+                "severity": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "message": {
+          "norms": false,
+          "type": "text"
+        },
+        "network": {
+          "properties": {
+            "application": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "community_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "direction": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "forwarded_ip": {
+              "type": "ip"
+            },
+            "iana_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "inner": {
+              "properties": {
+                "vlan": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "packets": {
+              "type": "long"
+            },
+            "protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "transport": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "vlan": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "observer": {
+          "properties": {
+            "egress": {
+              "properties": {
+                "interface": {
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "vlan": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingress": {
+              "properties": {
+                "interface": {
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "vlan": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "product": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "serial_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "vendor": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "organization": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "os": {
+          "properties": {
+            "family": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "kernel": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "platform": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "package": {
+          "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "build_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "checksum": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "install_scope": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "installed": {
+              "type": "date"
+            },
+            "license": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "size": {
+              "type": "long"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "pe": {
+          "properties": {
+            "company": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "file_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original_file_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "product": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "process": {
+          "properties": {
+            "args": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "args_count": {
+              "type": "long"
+            },
+            "code_signature": {
+              "properties": {
+                "exists": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "command_line": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "entity_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "executable": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exit_code": {
+              "type": "long"
+            },
+            "hash": {
+              "properties": {
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "parent": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "code_signature": {
+                  "properties": {
+                    "exists": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "trusted": {
+                      "type": "boolean"
+                    },
+                    "valid": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "command_line": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exit_code": {
+                  "type": "long"
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pgid": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "ppid": {
+                  "type": "long"
+                },
+                "start": {
+                  "type": "date"
+                },
+                "thread": {
+                  "properties": {
+                    "id": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "title": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "uptime": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "pe": {
+              "properties": {
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "pgid": {
+              "type": "long"
+            },
+            "pid": {
+              "type": "long"
+            },
+            "ppid": {
+              "type": "long"
+            },
+            "program": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "start": {
+              "type": "date"
+            },
+            "thread": {
+              "properties": {
+                "id": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "title": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uptime": {
+              "type": "long"
+            },
+            "working_directory": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "registry": {
+          "properties": {
+            "data": {
+              "properties": {
+                "bytes": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "strings": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hive": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "key": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "value": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "related": {
+          "properties": {
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "user": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "rule": {
+          "properties": {
+            "author": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "license": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ruleset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uuid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "server": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "service": {
+          "properties": {
+            "ephemeral_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "node": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "state": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "source": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "stream": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "syslog": {
+          "properties": {
+            "facility": {
+              "type": "long"
+            },
+            "facility_label": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "priority": {
+              "type": "long"
+            },
+            "severity_label": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "threat": {
+          "properties": {
+            "framework": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tactic": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "technique": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "timeseries": {
+          "properties": {
+            "instance": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "tls": {
+          "properties": {
+            "cipher": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "client": {
+              "properties": {
+                "certificate": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "certificate_chain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "issuer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ja3": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "server_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "supported_ciphers": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "curve": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "established": {
+              "type": "boolean"
+            },
+            "next_protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "resumed": {
+              "type": "boolean"
+            },
+            "server": {
+              "properties": {
+                "certificate": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "certificate_chain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "issuer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ja3s": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "subject": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version_protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "tracing": {
+          "properties": {
+            "trace": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "transaction": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "url": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fragment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "password": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "port": {
+              "type": "long"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "scheme": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "username": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "user": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "email": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full_name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "user_agent": {
+          "properties": {
+            "device": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "vlan": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "vulnerability": {
+          "properties": {
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "classification": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "enumeration": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "report_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "scanner": {
+              "properties": {
+                "vendor": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "score": {
+              "properties": {
+                "base": {
+                  "type": "float"
+                },
+                "environmental": {
+                  "type": "float"
+                },
+                "temporal": {
+                  "type": "float"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "severity": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "lifecycle": {
+          "name": "ent-search-logs",
+          "rollover_alias": "ent-search-logs-8"
+        },
+        "mapping": {
+          "total_fields": {
+            "limit": 10000
+          }
+        },
+        "max_docvalue_fields_search": 200,
+        "number_of_replicas": 1,
+        "number_of_shards": 1,
+        "query": {
+          "default_field": [
+            "message",
+            "tags",
+            "agent.ephemeral_id",
+            "agent.id",
+            "agent.name",
+            "agent.type",
+            "agent.version",
+            "as.organization.name",
+            "client.address",
+            "client.as.organization.name",
+            "client.domain",
+            "client.geo.city_name",
+            "client.geo.continent_name",
+            "client.geo.country_iso_code",
+            "client.geo.country_name",
+            "client.geo.name",
+            "client.geo.region_iso_code",
+            "client.geo.region_name",
+            "client.mac",
+            "client.registered_domain",
+            "client.top_level_domain",
+            "client.user.domain",
+            "client.user.email",
+            "client.user.full_name",
+            "client.user.group.domain",
+            "client.user.group.id",
+            "client.user.group.name",
+            "client.user.hash",
+            "client.user.id",
+            "client.user.name",
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "container.id",
+            "container.image.name",
+            "container.image.tag",
+            "container.name",
+            "container.runtime",
+            "destination.address",
+            "destination.as.organization.name",
+            "destination.domain",
+            "destination.geo.city_name",
+            "destination.geo.continent_name",
+            "destination.geo.country_iso_code",
+            "destination.geo.country_name",
+            "destination.geo.name",
+            "destination.geo.region_iso_code",
+            "destination.geo.region_name",
+            "destination.mac",
+            "destination.registered_domain",
+            "destination.top_level_domain",
+            "destination.user.domain",
+            "destination.user.email",
+            "destination.user.full_name",
+            "destination.user.group.domain",
+            "destination.user.group.id",
+            "destination.user.group.name",
+            "destination.user.hash",
+            "destination.user.id",
+            "destination.user.name",
+            "dns.answers.class",
+            "dns.answers.data",
+            "dns.answers.name",
+            "dns.answers.type",
+            "dns.header_flags",
+            "dns.id",
+            "dns.op_code",
+            "dns.question.class",
+            "dns.question.name",
+            "dns.question.registered_domain",
+            "dns.question.subdomain",
+            "dns.question.top_level_domain",
+            "dns.question.type",
+            "dns.response_code",
+            "dns.type",
+            "ecs.version",
+            "error.code",
+            "error.id",
+            "error.message",
+            "error.stack_trace",
+            "error.type",
+            "event.action",
+            "event.category",
+            "event.code",
+            "event.dataset",
+            "event.hash",
+            "event.id",
+            "event.kind",
+            "event.module",
+            "event.original",
+            "event.outcome",
+            "event.provider",
+            "event.timezone",
+            "event.type",
+            "file.device",
+            "file.directory",
+            "file.extension",
+            "file.gid",
+            "file.group",
+            "file.hash.md5",
+            "file.hash.sha1",
+            "file.hash.sha256",
+            "file.hash.sha512",
+            "file.inode",
+            "file.mode",
+            "file.name",
+            "file.owner",
+            "file.path",
+            "file.target_path",
+            "file.type",
+            "file.uid",
+            "geo.city_name",
+            "geo.continent_name",
+            "geo.country_iso_code",
+            "geo.country_name",
+            "geo.name",
+            "geo.region_iso_code",
+            "geo.region_name",
+            "group.domain",
+            "group.id",
+            "group.name",
+            "hash.md5",
+            "hash.sha1",
+            "hash.sha256",
+            "hash.sha512",
+            "host.architecture",
+            "host.geo.city_name",
+            "host.geo.continent_name",
+            "host.geo.country_iso_code",
+            "host.geo.country_name",
+            "host.geo.name",
+            "host.geo.region_iso_code",
+            "host.geo.region_name",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.full",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.type",
+            "host.user.domain",
+            "host.user.email",
+            "host.user.full_name",
+            "host.user.group.domain",
+            "host.user.group.id",
+            "host.user.group.name",
+            "host.user.hash",
+            "host.user.id",
+            "host.user.name",
+            "http.request.body.content",
+            "http.request.method",
+            "http.request.referrer",
+            "http.response.body.content",
+            "http.version",
+            "log.level",
+            "log.logger",
+            "log.origin.file.name",
+            "log.origin.function",
+            "log.original",
+            "log.syslog.facility.name",
+            "log.syslog.severity.name",
+            "network.application",
+            "network.community_id",
+            "network.direction",
+            "network.iana_number",
+            "network.name",
+            "network.protocol",
+            "network.transport",
+            "network.type",
+            "observer.geo.city_name",
+            "observer.geo.continent_name",
+            "observer.geo.country_iso_code",
+            "observer.geo.country_name",
+            "observer.geo.name",
+            "observer.geo.region_iso_code",
+            "observer.geo.region_name",
+            "observer.hostname",
+            "observer.mac",
+            "observer.name",
+            "observer.os.family",
+            "observer.os.full",
+            "observer.os.kernel",
+            "observer.os.name",
+            "observer.os.platform",
+            "observer.os.version",
+            "observer.product",
+            "observer.serial_number",
+            "observer.type",
+            "observer.vendor",
+            "observer.version",
+            "organization.id",
+            "organization.name",
+            "os.family",
+            "os.full",
+            "os.kernel",
+            "os.name",
+            "os.platform",
+            "os.version",
+            "package.architecture",
+            "package.checksum",
+            "package.description",
+            "package.install_scope",
+            "package.license",
+            "package.name",
+            "package.path",
+            "package.version",
+            "process.args",
+            "text",
+            "process.executable",
+            "process.hash.md5",
+            "process.hash.sha1",
+            "process.hash.sha256",
+            "process.hash.sha512",
+            "process.name",
+            "text",
+            "text",
+            "text",
+            "text",
+            "text",
+            "process.thread.name",
+            "process.title",
+            "process.working_directory",
+            "server.address",
+            "server.as.organization.name",
+            "server.domain",
+            "server.geo.city_name",
+            "server.geo.continent_name",
+            "server.geo.country_iso_code",
+            "server.geo.country_name",
+            "server.geo.name",
+            "server.geo.region_iso_code",
+            "server.geo.region_name",
+            "server.mac",
+            "server.registered_domain",
+            "server.top_level_domain",
+            "server.user.domain",
+            "server.user.email",
+            "server.user.full_name",
+            "server.user.group.domain",
+            "server.user.group.id",
+            "server.user.group.name",
+            "server.user.hash",
+            "server.user.id",
+            "server.user.name",
+            "service.ephemeral_id",
+            "service.id",
+            "service.name",
+            "service.node.name",
+            "service.state",
+            "service.type",
+            "service.version",
+            "source.address",
+            "source.as.organization.name",
+            "source.domain",
+            "source.geo.city_name",
+            "source.geo.continent_name",
+            "source.geo.country_iso_code",
+            "source.geo.country_name",
+            "source.geo.name",
+            "source.geo.region_iso_code",
+            "source.geo.region_name",
+            "source.mac",
+            "source.registered_domain",
+            "source.top_level_domain",
+            "source.user.domain",
+            "source.user.email",
+            "source.user.full_name",
+            "source.user.group.domain",
+            "source.user.group.id",
+            "source.user.group.name",
+            "source.user.hash",
+            "source.user.id",
+            "source.user.name",
+            "threat.framework",
+            "threat.tactic.id",
+            "threat.tactic.name",
+            "threat.tactic.reference",
+            "threat.technique.id",
+            "threat.technique.name",
+            "threat.technique.reference",
+            "tracing.trace.id",
+            "tracing.transaction.id",
+            "url.domain",
+            "url.extension",
+            "url.fragment",
+            "url.full",
+            "url.original",
+            "url.password",
+            "url.path",
+            "url.query",
+            "url.registered_domain",
+            "url.scheme",
+            "url.top_level_domain",
+            "url.username",
+            "user.domain",
+            "user.email",
+            "user.full_name",
+            "user.group.domain",
+            "user.group.id",
+            "user.group.name",
+            "user.hash",
+            "user.id",
+            "user.name",
+            "user_agent.device.name",
+            "user_agent.name",
+            "text",
+            "user_agent.original",
+            "user_agent.os.family",
+            "user_agent.os.full",
+            "user_agent.os.kernel",
+            "user_agent.os.name",
+            "user_agent.os.platform",
+            "user_agent.os.version",
+            "user_agent.version",
+            "text",
+            "agent.hostname",
+            "timeseries.instance",
+            "cloud.project.id",
+            "cloud.image.id",
+            "host.os.build",
+            "host.os.codename",
+            "log.file.path",
+            "log.source.address",
+            "stream",
+            "input.type",
+            "syslog.severity_label",
+            "syslog.facility_label",
+            "process.program",
+            "log.flags",
+            "user_agent.os.full_name",
+            "fileset.name",
+            "icmp.code",
+            "icmp.type",
+            "igmp.type",
+            "azure.eventhub",
+            "azure.consumer_group",
+            "kafka.topic",
+            "kafka.key",
+            "elasticsearch.component",
+            "elasticsearch.cluster.uuid",
+            "elasticsearch.cluster.name",
+            "elasticsearch.node.id",
+            "elasticsearch.node.name",
+            "elasticsearch.index.name",
+            "elasticsearch.index.id",
+            "elasticsearch.shard.id",
+            "elasticsearch.audit.layer",
+            "elasticsearch.audit.event_type",
+            "elasticsearch.audit.origin.type",
+            "elasticsearch.audit.realm",
+            "elasticsearch.audit.user.realm",
+            "elasticsearch.audit.user.roles",
+            "elasticsearch.audit.action",
+            "elasticsearch.audit.url.params",
+            "elasticsearch.audit.indices",
+            "elasticsearch.audit.request.id",
+            "elasticsearch.audit.request.name",
+            "elasticsearch.audit.message",
+            "elasticsearch.gc.phase.name",
+            "elasticsearch.gc.tags",
+            "elasticsearch.slowlog.logger",
+            "elasticsearch.slowlog.took",
+            "elasticsearch.slowlog.types",
+            "elasticsearch.slowlog.stats",
+            "elasticsearch.slowlog.search_type",
+            "elasticsearch.slowlog.source_query",
+            "elasticsearch.slowlog.extra_source",
+            "elasticsearch.slowlog.total_hits",
+            "elasticsearch.slowlog.total_shards",
+            "elasticsearch.slowlog.routing",
+            "elasticsearch.slowlog.id",
+            "elasticsearch.slowlog.type",
+            "elasticsearch.slowlog.source",
+            "kibana.log.tags",
+            "kibana.log.state",
+            "fields.*"
+          ]
+        },
+        "refresh_interval": "5s"
+      }
+    }
+  }
+}

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -19,6 +19,11 @@ output.elasticsearch:
   # Index name for Enterprise Search logs
   index: "ent-search-logs-8"
   bulk_max_size: 50
+  # Set to "none" if your Elasticsearch instance is not secured.
+  ssl.verification_mode: full
+  ssl.enabled: true
+  ssl.certificate: "<path_to_elasticsearch_cert_pem>"
+  ssl.key: "<path_to_elasticsearch_cert_key>"
 
 setup.template:
   overwrite: false
@@ -35,6 +40,15 @@ setup.ilm:
 processors:
   - drop_event.when.has_fields:
       - labels.skip_ingest
+
+# -------------------------------- Kibana Setup --------------------------------
+setup.kibana:
+  host: "<kibana_host>" # e.g. https://localhost:5601
+  # Set to "none" if your Kibana instance is not secured.
+  ssl.verification_mode: full
+  ssl.enabled: true
+  ssl.certificate: "<path_to_elasticsearch_cert_pem>"
+  ssl.key: "<path_to_elasticsearch_cert_key>"
 
 # ============================= Filebeat Logging ===============================
 logging.level: info

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -51,7 +51,7 @@ filebeat.inputs:
   - type: filestream
     id: enterprise_search_logs
     paths:
-      - "<enterprise-search-dir>log/app-server.log*"
+      - "<enterprise-search-dir>/log/app-server.log*"
     parsers:
       - multiline:
           type: pattern
@@ -73,7 +73,7 @@ filebeat.inputs:
   - type: filestream
     id: connector_logs
     paths:
-      - "<enterprise-search-dir>log/connectors.log*"
+      - "<enterprise-search-dir>/log/connectors.log*"
     parsers:
       - multiline:
           type: pattern
@@ -92,7 +92,7 @@ filebeat.inputs:
   - type: filestream
     id: crawler_logs
     paths:
-      - "<enterprise-search-dir>log/crawler.log*"
+      - "<enterprise-search-dir>/log/crawler.log*"
     parsers:
       - multiline:
           type: pattern
@@ -111,7 +111,7 @@ filebeat.inputs:
   - type: filestream
     id: api_analytics_logs
     paths:
-      - "<enterprise-search-dir>log/filebeat.log*"
+      - "<enterprise-search-dir>/log/filebeat.log*"
     parsers:
       - ndjson:
           keys_under_root: true
@@ -133,7 +133,7 @@ filebeat.inputs:
   - type: filestream
     id: http_requests_logs
     paths:
-      - "<enterprise-search-dir>log/system.log*"
+      - "<enterprise-search-dir>/log/system.log*"
     parsers:
       - ndjson:
           keys_under_root: true

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,0 +1,183 @@
+################## Enterprise Search Filebeat Configuration Example #####################
+
+# This file is an example configuration file for ingesting Enterprise Search logs into
+# Elasticsearch highlighting only the most common options.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
+
+# For more available modules and options, please see the filebeat.reference.yml sample
+# configuration file in Filebeat install directory.
+
+# ---------------------------- Elasticsearch Output ----------------------------
+output.elasticsearch:
+  hosts: ["<elasticsearch_host>"]
+  username: "<elasticsearch_username>"
+  password: "<elasticsearch_password>"
+  # SSL verification mode: true or false
+  ssl.verification_mode: <elasticsearch_ssl_verification_mode>
+
+setup.ilm.enabled: true
+
+# ================================== Logging ===================================
+logging.level: info
+logging.to_files: true
+logging.json: true
+logging.files:
+  path: <filebeat_log_dir>
+  name: filebeat.log
+  keepfiles: 3
+
+# ============================== Filebeat inputs ===============================
+filebeat.inputs:
+  # Enterprise Search main log
+  - type: log
+    paths:
+      - "<enterprise_search_dir>/logs/app-server.log*"
+    enabled: true
+    json.message_key:
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    fields:
+      event.dataset: enterprise_search.server
+      # The following fields are set as an example for identifying the deployment,
+      #  Enterprise Search version, and specific nodes. Any fields specified in this
+      #  section will be added to the log events
+      service.name: '<deployment_name>'
+      service.id: '<deployment_id>'
+      service.version: '<instance_version>'
+      service.node.name: '<instance_id>'
+    fields_under_root: true
+
+    # Automated processes log
+  - type: log
+    paths:
+      - "<enterprise_search_dir>/logs/worker.log*"
+    enabled: true
+    json.message_key:
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    fields:
+      event.dataset: enterprise_search.worker
+      service.name: '<deployment_name>'
+      service.id: '<deployment_id>'
+      service.version: '<instance_version>'
+      service.node.name: '<instance_id>'
+    fields_under_root: true
+
+    # Workplace Search connectors log
+  - type: log
+    paths:
+      - "<enterprise_search_dir>/logs/connectors.log*"
+    enabled: true
+    json.message_key:
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    fields:
+      event.dataset: enterprise_search.connectors
+      service.name: '<deployment_name>'
+      service.id: '<deployment_id>'
+      service.version: '<instance_version>'
+      service.node.name: '<instance_id>'
+    fields_under_root: true
+
+    # Crawler log
+  - type: log
+    paths:
+      - "<enterprise_search_dir>/logs/crawler.log*"
+    enabled: true
+    json.message_key:
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    fields:
+      event.dataset: enterprise_search.crawler
+      service.name: '<deployment_name>'
+      service.id: '<deployment_id>'
+      service.version: '<instance_version>'
+      service.node.name: '<instance_id>'
+    fields_under_root: true
+
+    # Filebeat log
+  - type: log
+    paths:
+      - "<enterprise_search_dir>/logs/filebeat*"
+    enabled: true
+    fields:
+      event.dataset: enterprise_search.filebeat
+      service.name: '<deployment_name>'
+      service.id: '<deployment_id>'
+      service.node.name: '<instance_id>'
+      service.version: '<instance_version>'
+      service.type: 'enterprise-search'
+    fields_under_root: true
+    processors:
+      - dissect:
+          tokenizer: "%{timestamp}\t%{log.level}\t%{message2}"
+          field: message
+          target_prefix: ""
+      - timestamp:
+          field: timestamp
+          layouts:
+            - '2006-01-02T15:04:05.999Z'
+      - drop_fields:
+          fields: [message]
+      - rename:
+          fields:
+            - from: message2
+              to: message
+      - drop_fields:
+          fields: [timestamp]
+
+    # HTTP Requests log
+  - type: log
+    paths:
+      - "<enterprise_search_dir>/logs/system.log*"
+    enabled: true
+    json.message_key:
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    fields:
+      event.dataset: enterprise_search.system
+      service.name: '<deployment_name>'
+      service.id: '<deployment_id>'
+      service.node.name: '<instance_id>'
+      service.version: '<instance_version>'
+      service.type: 'enterprise-search'
+    fields_under_root: true
+    processors:
+      - timestamp:
+          field: timestamp
+          layouts:
+            - '2006-01-02T15:04:05-07:00'
+      - script:
+          lang: javascript
+          id: convert_duration
+          source: >
+            function process(event) {
+              var duration = event.Get("duration");
+              if (duration) {
+                event.Put("event.duration", Math.round(duration * 1000000000));
+                event.Delete("duration");
+              }
+
+              return event;
+            }
+      - drop_fields:
+          fields: [timestamp]
+      - rename:
+          ignore_missing: true
+          fields:
+            - from: method
+              to: http.request.method
+            - from: http_version
+              to: http.version
+            - from: status
+              to: http.response.status_code
+            - from: request_body_size
+              to: http.request.body.bytes
+            - from: response_body_size
+              to: http.response.body.bytes
+            - from: path
+              to: url.path
+            - from: host
+              to: url.original

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -3,6 +3,8 @@
 # This file is an example configuration file for ingesting Enterprise Search logs into
 # Elasticsearch highlighting only the most common options.
 #
+# Logs will be ingested into filebeat-{filebeat-version}
+#
 # You can find the full configuration reference here:
 # https://www.elastic.co/guide/en/beats/filebeat/index.html
 
@@ -14,12 +16,27 @@ output.elasticsearch:
   hosts: ["<elasticsearch_host>"]
   username: "<elasticsearch_username>"
   password: "<elasticsearch_password>"
-  # SSL verification mode: true or false
-  ssl.verification_mode: <elasticsearch_ssl_verification_mode>
+  # Index name for Enterprise Search logs
+  index: "ent-search-logs-8"
+  bulk_max_size: 50
 
-setup.ilm.enabled: true
+setup.template:
+  overwrite: false
+  json:
+    enabled: true
+    path: "filebeat-template-8.json"
+    name: "ent-search-logs-8"
+  name: "ent-search-logs-8"
+  pattern: "ent-search-logs-8*"
 
-# ================================== Logging ===================================
+setup.ilm:
+  policy_name: "ent-search-logs"
+
+processors:
+  - drop_event.when.has_fields:
+      - labels.skip_ingest
+
+# ============================= Filebeat Logging ===============================
 logging.level: info
 logging.to_files: true
 logging.json: true
@@ -31,13 +48,16 @@ logging.files:
 # ============================== Filebeat inputs ===============================
 filebeat.inputs:
   # Enterprise Search main log
-  - type: log
+  - type: filestream
+    id: enterprise_search_logs
     paths:
-      - "<enterprise_search_dir>/log/app-server.log*"
-    enabled: true
-    json.message_key:
-    json.keys_under_root: true
-    json.overwrite_keys: true
+      - "<enterprise-search-dir>log/app-server.log*"
+    parsers:
+      - multiline:
+          type: pattern
+          pattern: '^\['
+          negate: true
+          match: after
     fields:
       event.dataset: enterprise_search.server
       # The following fields are set as an example for identifying the deployment,
@@ -49,30 +69,17 @@ filebeat.inputs:
       service.node.name: '<instance_id>'
     fields_under_root: true
 
-    # Automated processes log
-  - type: log
-    paths:
-      - "<enterprise_search_dir>/log/worker.log*"
-    enabled: true
-    json.message_key:
-    json.keys_under_root: true
-    json.overwrite_keys: true
-    fields:
-      event.dataset: enterprise_search.worker
-      service.name: '<deployment_name>'
-      service.id: '<deployment_id>'
-      service.version: '<instance_version>'
-      service.node.name: '<instance_id>'
-    fields_under_root: true
-
     # Workplace Search connectors log
-  - type: log
+  - type: filestream
+    id: connector_logs
     paths:
-      - "<enterprise_search_dir>/log/connectors.log*"
-    enabled: true
-    json.message_key:
-    json.keys_under_root: true
-    json.overwrite_keys: true
+      - "<enterprise-search-dir>log/connectors.log*"
+    parsers:
+      - multiline:
+          type: pattern
+          pattern: '^\['
+          negate: true
+          match: after
     fields:
       event.dataset: enterprise_search.connectors
       service.name: '<deployment_name>'
@@ -82,13 +89,16 @@ filebeat.inputs:
     fields_under_root: true
 
     # Crawler log
-  - type: log
+  - type: filestream
+    id: crawler_logs
     paths:
-      - "<enterprise_search_dir>/log/crawler.log*"
-    enabled: true
-    json.message_key:
-    json.keys_under_root: true
-    json.overwrite_keys: true
+      - "<enterprise-search-dir>log/crawler.log*"
+    parsers:
+      - multiline:
+          type: pattern
+          pattern: '^\['
+          negate: true
+          match: after
     fields:
       event.dataset: enterprise_search.crawler
       service.name: '<deployment_name>'
@@ -97,71 +107,50 @@ filebeat.inputs:
       service.node.name: '<instance_id>'
     fields_under_root: true
 
-    # Filebeat log
-  - type: log
+    # API and Analytics log
+  - type: filestream
+    id: api_analytics_logs
     paths:
-      - "<enterprise_search_dir>/log/filebeat*"
-    enabled: true
+      - "<enterprise-search-dir>log/filebeat.log*"
+    parsers:
+      - ndjson:
+          keys_under_root: true
+          overwrite_keys: true
+          add_error_key: true
+    processors:
+      - drop_fields:
+          fields: ["data_stream"]
+          ignore_missing: false
     fields:
-      event.dataset: enterprise_search.filebeat
       service.name: '<deployment_name>'
       service.id: '<deployment_id>'
-      service.node.name: '<instance_id>'
       service.version: '<instance_version>'
-      service.type: 'enterprise-search'
+      service.node.name: '<instance_id>'
     fields_under_root: true
-    processors:
-      - dissect:
-          tokenizer: "%{timestamp}\t%{log.level}\t%{message2}"
-          field: message
-          target_prefix: ""
-      - timestamp:
-          field: timestamp
-          layouts:
-            - '2006-01-02T15:04:05.999Z'
-      - drop_fields:
-          fields: [message]
-      - rename:
-          fields:
-            - from: message2
-              to: message
-      - drop_fields:
-          fields: [timestamp]
+
 
     # HTTP Requests log
-  - type: log
+  - type: filestream
+    id: http_requests_logs
     paths:
-      - "<enterprise_search_dir>/log/system.log*"
-    enabled: true
-    json.message_key:
-    json.keys_under_root: true
-    json.overwrite_keys: true
+      - "<enterprise-search-dir>log/system.log*"
+    parsers:
+      - ndjson:
+          keys_under_root: true
+          overwrite_keys: true
+          add_error_key: true
     fields:
-      event.dataset: enterprise_search.system
+      event.dataset: enterprise_search.http_requests
       service.name: '<deployment_name>'
       service.id: '<deployment_id>'
-      service.node.name: '<instance_id>'
       service.version: '<instance_version>'
-      service.type: 'enterprise-search'
+      service.node.name: '<instance_id>'
     fields_under_root: true
     processors:
       - timestamp:
           field: timestamp
           layouts:
             - '2006-01-02T15:04:05-07:00'
-      - script:
-          lang: javascript
-          id: convert_duration
-          source: >
-            function process(event) {
-              var duration = event.Get("duration");
-              if (duration) {
-                event.Put("event.duration", Math.round(duration * 1000000000));
-                event.Delete("duration");
-              }
-
-              return event;
-            }
       - drop_fields:
           fields: [timestamp]
       - rename:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -33,7 +33,7 @@ filebeat.inputs:
   # Enterprise Search main log
   - type: log
     paths:
-      - "<enterprise_search_dir>/logs/app-server.log*"
+      - "<enterprise_search_dir>/log/app-server.log*"
     enabled: true
     json.message_key:
     json.keys_under_root: true
@@ -52,7 +52,7 @@ filebeat.inputs:
     # Automated processes log
   - type: log
     paths:
-      - "<enterprise_search_dir>/logs/worker.log*"
+      - "<enterprise_search_dir>/log/worker.log*"
     enabled: true
     json.message_key:
     json.keys_under_root: true
@@ -68,7 +68,7 @@ filebeat.inputs:
     # Workplace Search connectors log
   - type: log
     paths:
-      - "<enterprise_search_dir>/logs/connectors.log*"
+      - "<enterprise_search_dir>/log/connectors.log*"
     enabled: true
     json.message_key:
     json.keys_under_root: true
@@ -84,7 +84,7 @@ filebeat.inputs:
     # Crawler log
   - type: log
     paths:
-      - "<enterprise_search_dir>/logs/crawler.log*"
+      - "<enterprise_search_dir>/log/crawler.log*"
     enabled: true
     json.message_key:
     json.keys_under_root: true
@@ -100,7 +100,7 @@ filebeat.inputs:
     # Filebeat log
   - type: log
     paths:
-      - "<enterprise_search_dir>/logs/filebeat*"
+      - "<enterprise_search_dir>/log/filebeat*"
     enabled: true
     fields:
       event.dataset: enterprise_search.filebeat
@@ -131,7 +131,7 @@ filebeat.inputs:
     # HTTP Requests log
   - type: log
     paths:
-      - "<enterprise_search_dir>/logs/system.log*"
+      - "<enterprise_search_dir>/log/system.log*"
     enabled: true
     json.message_key:
     json.keys_under_root: true


### PR DESCRIPTION
- Add a Filebeat example configuration
-  Add a note in the ent-search-monitoring [readme](https://github.com/elastic/ent-search-monitoring/blob/main/README.md) that this filebeat example yml is available as a reference for users looking to configure data collection for their Enterprise Search logs.